### PR TITLE
strip new line at the end of pasted content

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function program() {
 
 function format() {
   var args = [].concat.apply([], arguments);
-  return 'echo ' + escape(args) + ' | ' + program();
+  return 'echo -n ' + escape(args) + ' | ' + program();
 }
 
 /**


### PR DESCRIPTION
If you call `to-clipboard` the text in the clipboard will appear with new line character at the end. For example calling `to-clipboard` with "text" will paste "text\n". This could be replicated under Mac OS X.
