### PR TITLE
add support for termux on android

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,8 @@ function program() {
       return 'clip';
     case 'linux':
       return 'xclip -selection clipboard';
+    case 'android':
+      return 'termux-clipboard-set'
   }
 }
 


### PR DESCRIPTION
I am using termux on android for my node environment a lot more. This adds the ability to set the clipboard in that environment. 

Could you please pull this, bump the version number and publish on npm? If unable, would you be able to give me rights on github/npm to do so? 

Thanks!

Ryan
