### PR TITLE
Use xsel instead of xclip on Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function program() {
     case 'win32':
       return 'clip';
     case 'linux':
-      return 'xclip -selection clipboard';
+      return 'xsel -bi';
     case 'android':
       return 'termux-clipboard-set'
     case 'darwin':


### PR DESCRIPTION
Hi, here I am again!

I'm now also using your package on linux, but whenever I try to copy anything synchronously, the process just hangs indefinitely. I'll let [xsel's manpage](https://linux.die.net/man/1/xsel) explain why this is happening.
Now in fact, xsel implements this correctly, and returns immediately. Xclip, however, just hangs for me (might be my setup, but I haven't been able to fix it) and never seems to exit from the point of view of node.
Since xsel claims to work across linuxes as well and is already installed in a number of places, I propose switching to xsel. Makes my setup work. :)

By the way, I also get an ENOENT when using the asynchronous API, because `spawn` now tries to execute the program named 'xclip -selection clipboard', which doesn't exist of course. But that's a different issue. (https://github.com/jonschlinkert/to-clipboard/pull/7 looks great to me, even though it's closed (?))